### PR TITLE
Fix documentation bug by using Stock("AAPL")

### DIFF
--- a/src/bars.jl
+++ b/src/bars.jl
@@ -9,7 +9,7 @@ documentation for further reference.
 ```julia
 broker = AlpacaBroker(<key_id>, <secret_key>)
 
-bars(broker, "AAPL",
+bars(broker, Stock("AAPL"),
      DateTime("2022-01-01T00:00:00"),
      DateTime("2023-01-01T00:00:00"),
      timeframe = Minute(1))

--- a/src/quotes.jl
+++ b/src/quotes.jl
@@ -9,7 +9,7 @@ documentation for further reference.
 ```julia
 broker = AlpacaBroker(<key_id>, <secret_key>)
 
-quotes(broker, "AAPL", DateTime("2022-01-01T14:30:00"), DateTime("2022-01-01T14:31:00"))
+quotes(broker, Stock("AAPL"), DateTime("2022-01-01T14:30:00"), DateTime("2022-01-01T14:31:00"))
 ```
 """
 quotes(b::AbstractBroker) = broker(b).cache.quote_data

--- a/src/trades.jl
+++ b/src/trades.jl
@@ -9,7 +9,7 @@ documentation for further reference.
 ```julia
 broker = AlpacaBroker(<key_id>, <secret_key>)
 
-trades(broker, "AAPL", DateTime("2022-01-01T14:30:00"), DateTime("2022-01-01T14:31:00"))
+trades(broker, Stock("AAPL"), DateTime("2022-01-01T14:30:00"), DateTime("2022-01-01T14:31:00"))
 ```
 """
 trades(b::AbstractBroker) = broker(b).cache.trade_data


### PR DESCRIPTION
I noticed a minor documentation bug while exploring your library.  It looks like you changed your API such that assets are wrapped in a type that isn't String.